### PR TITLE
justext dependency added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install .
 
 EXPOSE 5550
 
-ENV FLASK_APP=mementoembed/mementoembed.py
+ENV FLASK_APP=mementoembed
 
 CMD ["flask", "run", "--host", "0.0.0.0", "--port", "5550"]
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'tldextract',
         'httpcache',
         'lockfile',
+        'justext',
         'memento_client',
         'htmlmin',
         'dicttoxml',


### PR DESCRIPTION
Adds missing dependency to fix:

```
Error: While importing "mementoembed.mementoembed", an ImportError was raised:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 235, in locate_app
    __import__(module_name)
  File "/app/mementoembed/__init__.py", line 12, in <module>
    from .mementosurrogate import MementoSurrogate, NotMementoException, \
  File "/app/mementoembed/mementosurrogate.py", line 16, in <module>
    from justext import justext, get_stoplist
ModuleNotFoundError: No module named 'justext'
```

Still needs fix: `Error: Could not import "mementoembed.mementoembed".`