### PR TITLE
Added dockerignore for more efficient build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+README.md
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .gitignore
 README.md
 Dockerfile
+LICENSE


### PR DESCRIPTION
Adding `.dockerignore` to reduce the docker build time and size.