### PR TITLE
Meta redirect error from cnn

### DIFF
--- a/instance/application.cfg
+++ b/instance/application.cfg
@@ -3,4 +3,4 @@ CACHEHOST = 'localhost'
 CACHEPORT = '6379'
 CACHEDB = '0'
 LOGFILE = '/app/mementoembed.log'
-LOGLEVEL = "logging.INFO"
+LOGLEVEL = "logging.DEBUG"

--- a/mementoembed/mementoresource.py
+++ b/mementoembed/mementoresource.py
@@ -71,7 +71,7 @@ def memento_resource_factory(urim, http_cache):
                         # assume the user is expected to read it, meaning
                         # it contains actual content and is not just a 
                         # pass-through
-                        if int(rtimeout) > 30:
+                        if int(rtimeout) < 30:
 
                             url = redir_info[1]
                             url = url.split('=', 1)[1]

--- a/mementoembed/mementoresource.py
+++ b/mementoembed/mementoresource.py
@@ -59,8 +59,8 @@ def memento_resource_factory(urim, http_cache):
 
                 if tag.get("content"):
 
-                    url = [i.strip() for i in tag.get("content").split(';')][1]
-                    url = url.split('=')[1]
+                    url = [i.strip() for i in tag.get("content").split(';', 1)][1]
+                    url = url.split('=', 1)[1]
                     url = url.strip('"')
                     redirect_url = url.strip("'")
                     urim = redirect_url
@@ -68,6 +68,9 @@ def memento_resource_factory(urim, http_cache):
                     module_logger.info("acquiring redirected URI-M {}".format(urim))
 
                     resp = http_cache.get(urim)
+
+                    module_logger.debug("for redirected URI-M {}, I got a response of {}".format(urim, resp))
+                    module_logger.debug("content: {}".format(resp.text))
 
                     if resp.status_code == 200:
                         soup = BeautifulSoup(resp.text, "html5lib")


### PR DESCRIPTION
This fixes #72 where the page redirect URI was not computed properly and it also provides a threshold for redirect timeouts.