### PR TITLE
Favicon issue

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Shawn M. Jones'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2018.09.05.234815'
+release = '0.2018.09.06.202242'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mementoembed/favicon.py
+++ b/mementoembed/favicon.py
@@ -52,18 +52,20 @@ def get_favicon_from_html(content):
 
     for link in links:
 
-        if 'icon' in link['rel']:
-            favicon_uri = link['href']
-            break
+        if 'rel' in link:
+            if 'icon' in link['rel']:
+                favicon_uri = link['href']
+                break
 
     # if that fails, try the older, nonstandard relation 'shortcut'
     if favicon_uri == None:
 
         for link in links:
 
-            if 'shortcut' in link['rel']:
-                favicon_uri = link['href']
-                break
+            if 'rel' in link:
+                if 'shortcut' in link['rel']:
+                    favicon_uri = link['href']
+                    break
 
     return favicon_uri
 

--- a/mementoembed/favicon.py
+++ b/mementoembed/favicon.py
@@ -52,20 +52,27 @@ def get_favicon_from_html(content):
 
     for link in links:
 
-        if 'rel' in link:
+        try:
             if 'icon' in link['rel']:
                 favicon_uri = link['href']
                 break
+        except KeyError:
+            module_logger.exception("there was no 'rel' attribute in this link tag: {}".format(link))
+            favicon_uri == None
 
     # if that fails, try the older, nonstandard relation 'shortcut'
     if favicon_uri == None:
 
         for link in links:
 
-            if 'rel' in link:
+            try:
                 if 'shortcut' in link['rel']:
                     favicon_uri = link['href']
                     break
+            except KeyError:
+                module_logger.exception("there was no 'rel' attribute in this link tag: {}".format(link))
+                favicon_uri == None
+
 
     return favicon_uri
 

--- a/mementoembed/version.py
+++ b/mementoembed/version.py
@@ -1,3 +1,3 @@
 __appname__ = "MementoEmbed"
-__appversion__ = '0.2018.09.05.234815'
+__appversion__ = '0.2018.09.06.202242'
 __useragent__ = "{}/{}".format(__appname__, __appversion__)

--- a/tests/test_archiveresource.py
+++ b/tests/test_archiveresource.py
@@ -279,3 +279,52 @@ class TestArchiveResource(unittest.TestCase):
         x = ArchiveResource(urim, httpcache)
 
         self.assertEqual(x.favicon, expected_favicon)
+
+    def test_link_tag_no_rel(self):
+
+        expected_favicon = None
+
+        cachedict = {
+            "http://myarchive.org":
+                mock_response(
+                    headers={},
+                    content="""<html>
+                    <head>
+                        <title>Is this a good title?</title>
+                        <link title="a good title" href="content/favicon.ico">
+                    </head>
+                    <body>Is this all there is to content?</body>
+                    </html>""",
+                    status=200,
+                    url = "testing-url://notused"
+                ),
+            expected_favicon:
+                mock_response(
+                    headers = { 'content-type': 'image/x-testing'},
+                    content = "a",
+                    status=200,
+                    url = "testing-url://notused"
+                ),
+            "http://myarchive.org/favicon.ico":
+                mock_response(
+                    headers={},
+                    content="not found",
+                    status=404,
+                    url="testing-url://notused"
+                ),
+            "https://www.google.com/s2/favicons?domain=myarchive.org":
+                mock_response(
+                    headers={},
+                    content="not found",
+                    status=404,
+                    url="testing-url://notused"
+                )
+        }
+
+        httpcache = mock_httpcache(cachedict)
+
+        urim = "http://myarchive.org/20160518000858/http://example.com/somecontent"
+
+        x = ArchiveResource(urim, httpcache)
+
+        self.assertEqual(x.favicon, expected_favicon)


### PR DESCRIPTION
fixes #129, MementoEmbed now no longer assumes that every HTML `link` tag has a `rel` attribute