### PR TITLE
fixes #128, a default blank image is now returned if none can be found

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Shawn M. Jones'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2018.09.06.202242'
+release = '0.2018.09.07.000916'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mementoembed/imageselection.py
+++ b/mementoembed/imageselection.py
@@ -81,6 +81,8 @@ def get_image_list(uri, http_cache):
     try:
         r = http_cache.get(uri)
 
+        module_logger.debug("content from URI-M: {}".format(r.text))
+
         try:
             soup = BeautifulSoup(r.text, 'html5lib')
         except Exception as e:

--- a/mementoembed/mementoresource.py
+++ b/mementoembed/mementoresource.py
@@ -125,6 +125,8 @@ def get_original_uri_from_response(response):
         raise NotAMementoError(
             "link header coult not be parsed for original URI",
             response=response, original_exception=e)
+    except aiu.timemap.MalformedLinkFormatTimeMap as e:
+        module_logger.exception("Failed to process link header for URI-R, link header: {}".format(response.headers['link']))
 
     return urir
 

--- a/mementoembed/services/memento.py
+++ b/mementoembed/services/memento.py
@@ -95,10 +95,14 @@ def bestimage(urim, preferences):
 
     best_image_uri = get_best_image(memento.urim, httpcache)
 
-    if preferences['datauri_image'].lower() == 'yes':
-        best_image_uri = convert_imageuri_to_pngdata_uri(
-            best_image_uri, httpcache, 96
-        )
+    if best_image_uri == None:
+        best_image_uri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+    else:
+
+        if preferences['datauri_image'].lower() == 'yes':
+            best_image_uri = convert_imageuri_to_pngdata_uri(
+                best_image_uri, httpcache, 96
+            )
 
     output = {}
 

--- a/mementoembed/services/product.py
+++ b/mementoembed/services/product.py
@@ -77,6 +77,14 @@ def generate_socialcard_response(urim, preferences):
     original_favicon_uri = s.original_favicon
     striking_image_uri = s.striking_image
 
+    if striking_image_uri == None:
+        striking_image_uri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+    else:
+        if preferences['datauri_image'].lower() == 'yes':
+            striking_image_uri = convert_imageuri_to_pngdata_uri(
+                striking_image_uri, httpcache, 96
+            )
+
     if preferences['datauri_favicon'].lower() == 'yes':
         original_favicon_uri = convert_imageuri_to_pngdata_uri(
             original_favicon_uri, httpcache, 16, 16
@@ -85,10 +93,6 @@ def generate_socialcard_response(urim, preferences):
             archive_favicon_uri, httpcache, 16, 16
         )
 
-    if preferences['datauri_image'].lower() == 'yes':
-        striking_image_uri = convert_imageuri_to_pngdata_uri(
-            striking_image_uri, httpcache, 96
-        )
 
     data = generate_social_card_html(
         urim, s, urlroot, archive_favicon_uri, 

--- a/mementoembed/version.py
+++ b/mementoembed/version.py
@@ -1,3 +1,3 @@
 __appname__ = "MementoEmbed"
-__appversion__ = '0.2018.09.06.202242'
+__appversion__ = '0.2018.09.07.000916'
 __useragent__ = "{}/{}".format(__appname__, __appversion__)


### PR DESCRIPTION
When no images can be found on the page, this fix will provide a blank one.