### PR TITLE
Fixes #136, link headers should now parse correctly in all cases

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Shawn M. Jones'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2018.10.11.153710'
+release = '0.2018.10.11.193540'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mementoembed/mementoresource.py
+++ b/mementoembed/mementoresource.py
@@ -105,8 +105,9 @@ def get_timegate_from_response(response):
     urig = None
 
     try:
-        urig = aiu.convert_LinkTimeMap_to_dict(
-            response.headers['link'] )['timegate_uri']
+        # urig = aiu.convert_LinkTimeMap_to_dict(
+        #     response.headers['link'] )['timegate_uri']
+        urig = response.links['timegate']['url']
     except KeyError as e:
         raise NotAMementoError(
             "link header coult not be parsed for timegate URI",
@@ -119,8 +120,9 @@ def get_original_uri_from_response(response):
     urir = None
 
     try:
-        urir = aiu.convert_LinkTimeMap_to_dict(
-            response.headers['link'] )['original_uri']
+        # urir = aiu.convert_LinkTimeMap_to_dict(
+        #     response.headers['link'] )['original_uri']
+        urir = response.links['original']['url']
     except KeyError as e:
         raise NotAMementoError(
             "link header coult not be parsed for original URI",

--- a/mementoembed/version.py
+++ b/mementoembed/version.py
@@ -1,3 +1,3 @@
 __appname__ = "MementoEmbed"
-__appversion__ = '0.2018.10.11.153710'
+__appversion__ = '0.2018.10.11.193540'
 __useragent__ = "{}/{}".format(__appname__, __appversion__)

--- a/tests/test_mementoresource.py
+++ b/tests/test_mementoresource.py
@@ -13,10 +13,11 @@ testdir = os.path.dirname(os.path.realpath(__file__))
 
 class mock_response:
 
-    def __init__(self, headers, text, status, url, content=None):
+    def __init__(self, headers, text, status, url, content=None, links={}):
         self.headers = headers
         self.text = text
         self.url = url
+        self.links = links
         
         if content is None:
 
@@ -82,7 +83,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urig: # requests follows all redirects, so we present the result at the end of the chain
                 mock_response(
@@ -97,7 +106,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 )
         }
 
@@ -160,7 +177,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             raw_urim:
                 mock_response(
@@ -232,7 +257,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             raw_urim:
                 mock_response(
@@ -314,7 +347,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             zipurim:
                 mock_response(
@@ -476,7 +517,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             "http://archive.is/20130508132946id_/http://flexispy.com/":
                 mock_response(
@@ -552,7 +601,15 @@ class TestMementoResource(unittest.TestCase):
                     text = metaredirecthtml,
                     content = metaredirecthtml,
                     status = 200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             redirurim: 
                 mock_response(
@@ -568,7 +625,15 @@ class TestMementoResource(unittest.TestCase):
                     text = expected_content,
                     content = expected_content,
                     status = 200,
-                    url = redirurim
+                    url = redirurim,
+                    links = {
+                        "original": {
+                            "url": redir_expected_original_uri
+                        },
+                        "timegate": {
+                            "url": redir_expected_urig
+                        }
+                    }
                 ),
             redirurim_raw: 
                 mock_response(
@@ -624,7 +689,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_raw_uri:
                 mock_response(
@@ -639,7 +712,15 @@ class TestMementoResource(unittest.TestCase):
                     },
                     text = expected_raw_content,
                     status = 200,
-                    url = expected_raw_uri
+                    url = expected_raw_uri,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urig: # requests follows all redirects, so we present the result at the end of the chain
                 mock_response(
@@ -654,7 +735,15 @@ class TestMementoResource(unittest.TestCase):
                      },
                     text = expected_content,
                     status = 200, # after following redirects
-                    url = expected_urim
+                    url = expected_urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urim:
                 mock_response(
@@ -669,7 +758,15 @@ class TestMementoResource(unittest.TestCase):
                      },
                     text = expected_content,
                     status = 200, # after following redirects
-                    url = expected_urim
+                    url = expected_urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 )
         }
 

--- a/tests/test_originalresource.py
+++ b/tests/test_originalresource.py
@@ -5,7 +5,7 @@ from mementoembed.originalresource import OriginalResource
 
 class mock_response:
 
-    def __init__(self, headers, text, status, url, content=None):
+    def __init__(self, headers, text, status, url, content=None, links={}):
         self.headers = headers
         self.text = text
         if content is None:
@@ -15,6 +15,8 @@ class mock_response:
 
         self.status_code = status
         self.url = url
+
+        self.links = links
 
 class mock_httpcache:
     """
@@ -64,7 +66,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urig:
                 mock_response(
@@ -79,7 +89,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_original_uri:
                 mock_response(
@@ -130,7 +148,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urig:
                 mock_response(
@@ -145,7 +171,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_original_uri:
                 mock_response(
@@ -202,7 +236,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_urig:
                 mock_response(
@@ -217,7 +259,15 @@ class TestOriginalResource(unittest.TestCase):
                     },
                     text = expected_content,
                     status=200,
-                    url = urim
+                    url = urim,
+                    links = {
+                        "original": {
+                            "url": expected_original_uri
+                        },
+                        "timegate": {
+                            "url": expected_urig
+                        }
+                    }
                 ),
             expected_original_uri:
                 mock_response(


### PR DESCRIPTION
link headers should now parse correctly in all cases and all tests have been updated to account for the new behavior