### PR TITLE
Fix for URI-Ms that do not return images on first pass

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Shawn M. Jones'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2019.05.30.174143'
+release = '0.2019.05.30.192655'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mementoembed/services/memento.py
+++ b/mementoembed/services/memento.py
@@ -229,6 +229,19 @@ def imagedata(urim, preferences):
     for item in sorted(scorelist, reverse=True):
         output["ranked images"].append(item[1])
 
+    if len(output["ranked images"]) == 0:
+        output['images'] = generate_images_and_scores(memento.urim, httpcache)
+
+        scorelist = []
+        output["ranked images"] = []
+
+        for imageuri in output['images']:
+            if 'calculated score' in output['images'][imageuri]:
+                scorelist.append( (output['images'][imageuri]["calculated score"], imageuri) )
+
+        for item in sorted(scorelist, reverse=True):
+            output["ranked images"].append(item[1])
+
     response = make_response(json.dumps(output, indent=4))
     response.headers['Content-Type'] = 'application/json'
 

--- a/mementoembed/services/memento.py
+++ b/mementoembed/services/memento.py
@@ -167,11 +167,20 @@ def bestimage(urim, preferences):
 
     memento = memento_resource_factory(urim, httpcache)
 
+    module_logger.debug("trying to find best image with {}".format(memento.im_urim))
     best_image_uri = get_best_image(
         memento.im_urim, 
         httpcache,
         current_app.config['DEFAULT_IMAGE_URI']
     )
+
+    if best_image_uri == current_app.config['DEFAULT_IMAGE_URI']:
+        module_logger.debug("got back a blank image, trying again with {}".format(memento.urim))
+        best_image_uri = get_best_image(
+            memento.urim, 
+            httpcache,
+            current_app.config['DEFAULT_IMAGE_URI']
+        )   
 
     if preferences['datauri_image'].lower() == 'yes':
         if best_image_uri[0:5] != 'data:':

--- a/mementoembed/version.py
+++ b/mementoembed/version.py
@@ -1,3 +1,3 @@
 __appname__ = "MementoEmbed"
-__appversion__ = '0.2019.05.30.174143'
+__appversion__ = '0.2019.05.30.192655'
 __useragent__ = "{}/{}".format(__appname__, __appversion__)


### PR DESCRIPTION
Some Wayback im_ URI-Ms return HTML with no images on the first pass. This code has them re-run the same checks using the original URI-M in hopes of acquiring some images.